### PR TITLE
Unorphan correctly on different scenarios

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,10 +13,10 @@ void (function (root, factory) {
       unorphan(document.querySelectorAll(n))
     } else if (n.nodeType && n.nodeType === 1) {
       // ELEMENT_NODE
-      unorphan(lastNonSpaceChild(n))
-    } else if (n.nodeType && n.nodeType === 3) {
-      // TEXT_NODE
-      n.nodeValue = n.nodeValue.replace(/\s+([^\s]+\s*)$/g, '\xA0$1')
+      lastNonSpaceChilds(n).forEach(function (n) {
+        // Replace last spaces group with a non-breaking-space
+        n.nodeValue = n.nodeValue.replace(/(\s+)([^\s]*)$/g, '\xA0$2')
+      })
     } else if (n.length) {
       // node list or jQuery object
       for (var i = 0, len = n.length; i < len; i++) {
@@ -25,13 +25,97 @@ void (function (root, factory) {
     }
   }
 
-  function lastNonSpaceChild (node) {
-    for (var i = node.childNodes.length - 1; i >= 0; i--) {
-      var sub = node.childNodes[i]
-      if (sub.nodeType !== 3 || !sub.nodeValue.match(/^\s*$/)) {
-        return sub
+  // For each group of text nodes divided by <br>
+  // find the candidate for adding a non-breaking-space
+  //
+  // `str` is to check if the node makes a good candidate, e.g.:
+  //
+  // Given ['hello ', 'world '], start from the end:
+  //
+  // 1: 'world '       => NO
+  // 0: 'hello world ' => YES. Return the 'hello ' node and replace
+  //                      the last space with a non-breaking-space
+  //
+  function lastNonSpaceChilds (node) {
+    return textNodeGroups(node).map(function (group) {
+      var isCandidate = /\s+([^\s]+\s*)$/g
+      var str = ''
+
+      for (var i = group.length - 1; i >= 0; i--) {
+        str = group[i].nodeValue + str
+
+        // At the end, check for:
+        // spaces + alphanumeric + optional spaces
+        if (isCandidate.test(str)) {
+          return group[i]
+        }
       }
-    }
+
+      return null
+    }).filter(function (node) {
+      return node !== null
+    })
   }
 
+  // Groups the flattened DOM into groups of TEXT_NODES
+  // cut where <br/> elements are found, e.g.:
+  //
+  // [
+  //     TEXT_NODE("hello "),
+  //     TEXT_NODE("wonderfull"),
+  //     ELEMENT_NODE("BR"),
+  //     TEXT_NODE("world"),
+  //     TEXT_NODE("    "),
+  // ]
+  //
+  // [
+  //     [TEXT_NODE("hello "), TEXT_NODE("wonderfull")],
+  //     [TEXT_NODE("world"), TEXT_NODE("    ")],
+  // ]
+  function textNodeGroups (node) {
+    var nodes = flatten(node)
+    var group = []
+    var out = []
+
+    out.push(group)
+
+    for (var i = 0; i < nodes.length; i++) {
+      if (nodes[i].nodeType === 3) {
+        group.push(nodes[i])
+      } else {
+        group = []
+        out.push(group)
+      }
+    }
+
+    return out
+  }
+
+  // Flattens DOM, to get a list of TEXT_NODES + <BR>, e.g.:
+  //
+  // "hello <b>wonderfull<br>world</b>    ", becomes:
+  //
+  // [
+  //     TEXT_NODE("hello "),
+  //     TEXT_NODE("wonderfull"),
+  //     ELEMENT_NODE("BR"),
+  //     TEXT_NODE("world"),
+  //     TEXT_NODE("    "),
+  // ]
+  function flatten (node, out) {
+    out = out || []
+
+    for (var i = 0; i < node.childNodes.length; i++) {
+      var sub = node.childNodes[i]
+
+      // Get TEXT_NODES or ELEMENT_NODE(BR)
+      if (sub.nodeType === 3 || (sub.nodeType === 1 && sub.tagName === 'BR')) {
+        out.push(sub)
+      } else {
+        flatten(sub, out)
+      }
+    }
+
+    return out
+  }
 }))

--- a/test/test.js
+++ b/test/test.js
@@ -20,10 +20,50 @@ describe('unorphan', function () {
     expect(div.innerHTML).eql('hello there&nbsp;world')
   })
 
+  it('works with multiple spaces', function () {
+    div.innerHTML = 'hello there   world'
+    unorphan(div)
+    expect(div.innerHTML).eql('hello there&nbsp;world')
+  })
+
   it('works with html', function () {
     div.innerHTML = 'hello <b>there world</b>'
     unorphan(div)
     expect(div.innerHTML).eql('hello <b>there&nbsp;world</b>')
+  })
+
+  it('works with line feed in between', function () {
+    div.innerHTML = 'hello\n there\n\n world'
+    unorphan(div)
+    expect(div.innerHTML).eql('hello\n there&nbsp;world')
+  })
+
+  it('works with tags after space', function () {
+    div.innerHTML = 'hello there <b>world</b>'
+    unorphan(div)
+    expect(div.innerHTML).eql('hello there&nbsp;<b>world</b>')
+  })
+
+  it('works with spaces at the end', function () {
+    div.innerHTML = '<b>hello there world</b>    '
+    unorphan(div)
+    expect(div.innerHTML).eql('<b>hello there&nbsp;world</b>    ')
+
+    div.innerHTML = 'hello there <b>world </b>'
+    unorphan(div)
+    expect(div.innerHTML).eql('hello there&nbsp;<b>world </b>')
+  })
+
+  it('works with <br> tags', function () {
+    div.innerHTML = 'hello <span>there wonderfull<br>virtual world</span>'
+    unorphan(div)
+    expect(div.innerHTML).eql('hello <span>there&nbsp;wonderfull<br>virtual&nbsp;world</span>')
+  })
+
+  it('works on complex scenarios', function () {
+    div.innerHTML = 'hello <span>there\n\n   wonderfull<br>orphaned\n  virtual world</span><br/>abc    '
+    unorphan(div)
+    expect(div.innerHTML).eql('hello <span>there&nbsp;wonderfull<br>orphaned\n  virtual&nbsp;world</span><br>abc    ')
   })
 })
 


### PR DESCRIPTION
This should fix #3, it was tricky but interesting problem. :-)
It also fixes this case: `hello <b>world</b>`

![orphan-br](https://cloud.githubusercontent.com/assets/188612/8458037/096e71fa-2015-11e5-90e7-dd16bea54d4e.png)

By the way, maybe the `unorphan` function can be rewritten to do the job in one pass, without recursion?
